### PR TITLE
Feature/#35

### DIFF
--- a/lib/nose/backend/cassandra.rb
+++ b/lib/nose/backend/cassandra.rb
@@ -240,7 +240,7 @@ module NoSE
             fields = @index.all_fields.select { |field| result.key? field.id }
 
             # sort fields according to the Insert
-            fields.sort_by!{|field| @prepared.cql.index(field.id)}
+            fields.sort_by!{|field| @prepared.cql.index(field.id)} if @prepared.is_a? Cassandra::Statements::Prepared
 
             values = fields.map do |field|
               value = result[field.id]

--- a/lib/nose/backend/file.rb
+++ b/lib/nose/backend/file.rb
@@ -110,7 +110,7 @@ module NoSE
         include RowMatcher
 
         # Filter all the rows in the specified index to those requested
-        def process(conditions, results)
+        def process(conditions, results, _)
           # Get the set of conditions we need to process
           results = initial_results(conditions) if results.nil?
           condition_list = result_conditions conditions, results

--- a/lib/nose/serialize.rb
+++ b/lib/nose/serialize.rb
@@ -572,12 +572,14 @@ module NoSE
       collection :statements, decorator: StatementRepresenter
       property :mix
 
+      def workload_weights
+        represented.instance_variable_get(:@statement_weights)
+      end
+
       # Produce weights of each statement in the workload for each mix
       # @return [Hash]
       def weights
         weights = {}
-        workload_weights = represented \
-                           .instance_variable_get(:@statement_weights)
         workload_weights.each do |mix, mix_weights|
           weights[mix] = {}
           mix_weights.each do |statement, weight|
@@ -597,6 +599,11 @@ module NoSE
 
     class TimeDependWorkloadRepresenter < BasicWorkloadRepresenter
       collection :weights, exec_context: :decorator
+      property :is_static
+
+      def workload_weights
+        represented.instance_variable_get(:@time_depend_statement_weights)
+      end
     end
 
     # Represent entities in a model
@@ -637,6 +644,7 @@ module NoSE
         end
 
         workload.mix = fragment['mix'].to_sym unless fragment['mix'].nil?
+        workload.is_static = fragment['is_static'] if workload.is_a? TimeDependWorkload
 
         workload
       end

--- a/lib/nose/time_depend_workload.rb
+++ b/lib/nose/time_depend_workload.rb
@@ -9,10 +9,10 @@ module NoSE
   # A representation of a query workload over a given set of entities
   class TimeDependWorkload < Workload
 
-    attr_accessor :timesteps, :interval, :is_static
+    attr_accessor :timesteps, :interval, :is_static, :time_depend_statement_weights
 
     def initialize(model = nil, &block)
-      @statement_weights = { default: {} }
+      @time_depend_statement_weights = { default: {} }
       @model = model || Model.new
       @mix = :default
       @interval = 3600 # set seconds in an hour as default
@@ -20,6 +20,17 @@ module NoSE
 
       # Apply the DSL
       TimeDependWorkloadDSL.new(self).instance_eval(&block) if block_given?
+
+      # deep copy the weight hash
+      @statement_weights = Marshal.load(Marshal.dump(@time_depend_statement_weights))
+
+      if @is_static # if this workload is static workload, overwrite the value of frequency by the average frequency
+        @time_depend_statement_weights.each do |mix, statements|
+          statements.each do |statement, frequencies|
+            @statement_weights[mix][statement] = average_array(frequencies)
+          end
+        end
+      end
     end
 
     # Add a new {Statement} to the workload or parse a string
@@ -33,15 +44,15 @@ module NoSE
       mixes = { default: mixes } if mixes.is_a? Numeric
       mixes = { default: [1.0] * @timesteps } if mixes.empty?
       mixes.each do |mix, weight|
-        @statement_weights[mix] = {} unless @statement_weights.key? mix
+        @time_depend_statement_weights[mix] = {} unless @time_depend_statement_weights.key? mix
         fail "Frequency is required for #{statement.text}" if weight.nil? and frequency.nil?
         fail "number of Frequency should be same as timesteps for #{statement.text}" \
           unless weight.size == @timesteps or frequency&.size == @timestep
         fail "Frequency cannot become 0 for #{statement.text}" if weight.include?(0) or frequency&.include?(0)
         # ensure that all query has the same # of timesteps
-        fail if @statement_weights[mix].map{|_, weights| weights.size}.uniq.size > 1
+        fail if @time_depend_statement_weights[mix].map{|_, weights| weights.size}.uniq.size > 1
         frequencies = (frequency.nil? ? weight : frequency).map{|f| f * @interval}
-        @statement_weights[mix][statement] = is_static ? average_array(frequencies) : frequencies
+        @time_depend_statement_weights[mix][statement] = frequencies
       end
     end
 
@@ -72,6 +83,18 @@ module NoSE
       query = Query.new(params, nil, group: "PrepareQuery")
       query.set_text
       query
+    end
+
+    def time_depend_statement_weights
+      @time_depend_statement_weights[@mix]
+    end
+
+    # Strip the weights from the query dictionary and return a list of updates
+    # @return [Array<Statement>]
+    def updates
+      @time_depend_statement_weights[@mix].keys.reject do |statement|
+        statement.is_a? Query
+      end
     end
 
     private

--- a/lib/nose/worker.rb
+++ b/lib/nose/worker.rb
@@ -1,0 +1,134 @@
+# cited from https://qiita.com/yuroyoro/items/92c5bc864fa9c05127a9
+module NoSE
+  class Worker
+    attr_reader :pid
+
+    def initialize(&block)
+      @child_read, @parent_write = create_pipe
+      @parent_read, @child_write = create_pipe
+      @block = block
+    end
+
+    def create_pipe
+      # change the encoding to ASCII-8BIT
+      IO.pipe.map{|pipe| pipe.tap{|_| _.set_encoding("ASCII-8BIT", "ASCII-8BIT")}}
+    end
+
+    # run the child process
+    def run
+
+      @pid = fork do
+        @parent_read.close
+        @parent_write.close
+
+        # notify the start of child process
+        write_to_parent(:ready)
+
+        loop do
+          # waiting for the request from the parent
+          args = read_from_parent
+
+          # exit the loop and kill this child process when get stop
+          break if args == :stop
+
+          # execute the task
+          result = @block.call(*args)
+
+          # write the result to the pipe and notice the end of task
+          write_object(result, @child_write)
+        end
+
+        @child_read.close
+        @child_write.write
+      end
+
+      wait_after_fork if @pid
+    end
+
+    def execute(*msg)
+      write_to_child(msg)
+
+      Thread.new { read_from_child }
+    end
+
+    def stop
+      return unless alive?
+
+      # stop the child
+      write_to_child(:stop)
+
+      # wait for child by waitpid
+      Process.wait(@pid)
+    end
+
+    def write_object(obj, write)
+      # write ruby object to pipe by using Marshal
+      data = Marshal.dump(obj).gsub("\n", '\n') + "\n"
+      write.write data
+    end
+
+    def read_object(read)
+      # decode the object
+      data = read.gets
+      Marshal.load(data.chomp.gsub('\n', "\n"))
+    end
+
+    def write_to_child(obj)
+      write_object(obj, @parent_write)
+    end
+
+    def read_from_child
+      read_object(@parent_read)
+    end
+
+    def read_from_parent
+      read_object(@child_read)
+    end
+
+    def write_to_parent(obj)
+      write_object(obj, @child_write)
+    end
+
+    def wait_after_fork
+      @child_read.close
+      @child_write.close
+
+      install_exit_handler
+      install_signal_handler
+    end
+
+    def alive?
+      Process.kill(0, @pid)
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    def install_exit_handler
+      # exit the child by Kernel#at_exit
+      at_exit do
+        next unless alive?
+        begin
+          Process.kill("KILL", @pid)
+          Process.wait(@pid)
+        rescue Errno::ESRCH
+          # do nothing
+        rescue => e
+          puts "error at_exit: #{e}"
+          raise e
+        end
+      end
+    end
+
+    def install_signal_handler
+      # send parent's SIGINT and SIGQUIT to child
+      [:INT, :QUIT].each do |signal|
+        old_handler = Signal.trap(signal) {
+          Process.kill(signal, @pid)
+          Process.wait(@pid)
+          old_handler.call
+        }
+      end
+    end
+  end
+end

--- a/spec/backend/cassandra_backend_spec.rb
+++ b/spec/backend/cassandra_backend_spec.rb
@@ -101,7 +101,7 @@ module NoSE
         step_class = CassandraBackend::IndexLookupStatementStep
         prepared = step_class.new client, query.all_fields, query.conditions,
                                   step, nil, step.parent
-        prepared.process query.conditions, nil
+        prepared.process query.conditions, nil, nil
       end
     end
 

--- a/spec/backend/file_backend_spec.rb
+++ b/spec/backend/file_backend_spec.rb
@@ -88,7 +88,7 @@ module NoSE
         step_class = FileBackend::IndexLookupStatementStep
         prepared = step_class.new index_data, query.all_fields,
                                   query.conditions, step, nil, step.parent
-        results = prepared.process query.conditions, nil
+        results = prepared.process query.conditions, nil, nil
 
         # Verify we get the result we started with
         expect(results).to eq index_data[index.key]


### PR DESCRIPTION
To treat with the time-depend workload as the static workload that has the average frequency of the time_depend workload, I created a new variable that holds the time_depend frequency.
And I set the average value to statement_weights.
When executing the time_depend benchmark, this calculates the weighted frequency by using the time_depend frequency in the new variable. 