### PR TITLE
reduce the amount of records passed between processes

### DIFF
--- a/lib/nose/worker.rb
+++ b/lib/nose/worker.rb
@@ -32,10 +32,10 @@ module NoSE
           break if args == :stop
 
           # execute the task
-          result = @block.call(*args)
+          @block.call(*args)
 
           # write the result to the pipe and notice the end of task
-          write_object(result, @child_write)
+          write_object(:done, @child_write) # stop working if we send too big message
         end
 
         @child_read.close


### PR DESCRIPTION
The background process stops working if I pass too much large object to the pipe.